### PR TITLE
RISC-V aplic model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,9 @@ if(TARGET scc)
 	add_subdirectory(minres)
 	add_subdirectory(pulpino)
 	add_subdirectory(pulpissimo)
+	add_subdirectory(rvi)
 	add_library(${PROJECT_NAME} INTERFACE)
-	target_link_libraries(${PROJECT_NAME} INTERFACE ${PROJECT_NAME}_generic ${PROJECT_NAME}_minres ${PROJECT_NAME}_sifive ${PROJECT_NAME}_pulpino  ${PROJECT_NAME}_pulpissimo)	
+	target_link_libraries(${PROJECT_NAME} INTERFACE ${PROJECT_NAME}_generic ${PROJECT_NAME}_minres ${PROJECT_NAME}_sifive ${PROJECT_NAME}_pulpino  ${PROJECT_NAME}_pulpissimo ${PROJECT_NAME}_rvi)	
 	
 	install(TARGETS ${PROJECT_NAME}
 	        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/rvi/CMakeLists.txt
+++ b/rvi/CMakeLists.txt
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2025 MINRES Technologies GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+cmake_minimum_required(VERSION 3.12)
+
+###############################################################################
+# RVI
+###############################################################################
+add_library(${PROJECT_NAME}_rvi
+	aplic.cpp
+)
+if(USE_SC_SIGNAL4IRQ)
+    target_compile_definitions(${PROJECT_NAME}_rvi PUBLIC SC_SIGNAL_IF)
+endif()
+target_include_directories(${PROJECT_NAME}_rvi PUBLIC ${vpvper_SOURCE_DIR})
+if(SEASOCKS_LIB)
+	target_compile_definitions(${PROJECT_NAME}_rvi PUBLIC HAS_WEB_SOCKETS)
+	target_link_libraries(${PROJECT_NAME}_rvi PUBLIC ${PROJECT_NAME}_generic)
+endif()
+target_link_libraries(${PROJECT_NAME}_rvi PUBLIC ${PROJECT_NAME}_generic scc)
+add_library(${PROJECT_NAME}::rvi ALIAS ${PROJECT_NAME}_rvi)
+
+install(TARGETS ${PROJECT_NAME}_rvi COMPONENT ${PROJECT_NAME}_rvi
+  EXPORT ${PROJECT_NAME}_genericTargets                         # for downstream dependencies
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
+  FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR}         # for mac
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} # headers for mac (note the different component -> different package)
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}      # headers
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMPONENT ${PROJECT_NAME}_rvi
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} # target directory
+        FILES_MATCHING # install only matched files
+        PATTERN "*.h" # select header files
+        )

--- a/rvi/aplic.cpp
+++ b/rvi/aplic.cpp
@@ -1,0 +1,418 @@
+/*
+ * aplic.cpp - RISC-V APLIC model
+ *
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+ /* This model supports only the Direct delivery mode.
+  * It has been tested for a single hart (index:0) implementing only M-mode, with a single machine-level interrupt domain for that hart,
+  * and for level-triggered interrupts using source and target TLM signals.
+  * It also supports edge-triggered interrupts and SystemC signals, however, these features have not yet been validated.
+  * Additionally, functionality for the pendingnum, clripnum registers is not implemented.
+ */
+
+#include "aplic.h"
+#include "gen/aplic_regs.h"
+#include "tlm/scc/tlm_signal_gp.h"
+
+#include <scc/report.h>
+#include <scc/utilities.h>
+#include <tlm_core/tlm_2/tlm_generic_payload/tlm_phase.h>
+
+namespace vpvper {
+namespace rvi {
+
+aplic::aplic(sc_core::sc_module_name nm)
+: sc_core::sc_module(nm)
+, tlm_target<>(clk_period)
+, NAMEDD(regs, aplic_regs)
+, external_global_interrupts_i("external_global_interrupts_i", num_irq.get_value()){
+
+    SCCDEBUG(this->name()) << "Initialize Aplic Model with " << external_global_interrupts_i.size() << " interrupts";
+
+    regs->registerResources(*this);
+
+    // register callbacks
+
+    regs->sourcecfg.set_write_cb([this](size_t index, scc::sc_register<uint32_t>& reg, uint32_t data) -> bool {
+        uint32_t irq = index + 1;
+        if(irq > external_global_interrupts_i.size()) {
+            SCCDEBUG(this->name()) << "sourcecfg: The interrupt number " << irq << " exceeds the maximum value " << external_global_interrupts_i.size()<< " supported by the current configuration";
+        }else {
+            regs->r_sourcecfg[index] = data;
+        }
+        return true;
+    });
+
+    regs->targetcfg.set_write_cb([this](size_t index, scc::sc_register<uint32_t>& reg, uint32_t data) -> bool {
+        uint32_t irq = index + 1;
+        if(irq > external_global_interrupts_i.size()) {
+            SCCDEBUG(this->name()) << "target: The interrupt number " << irq << " exceeds the maximum value " << external_global_interrupts_i.size() << " supported by the current configuration";
+        }else {
+            uint32_t irq_priority = data & INTERRUPT_PRIO_MASk;
+            if(irq_priority > num_irq_prio.get_value()) {
+                SCCDEBUG(this->name()) << "target: The interrupt priority " << irq_priority << " exceeds the maximum value " << num_irq_prio.get_value() << " supported by the current configuration";
+            }else {
+                // only values 1 through Max are allowed for Interrupt Priority, not zero.
+                if(irq_priority != 0) {
+                    regs->r_targetcfg[index] = data;
+                }
+            }
+        }
+        return true;
+    });
+
+    regs->enablednum.set_write_cb([this](scc::sc_register<uint32_t>& reg, uint32_t data, sc_core::sc_time d) -> bool {
+
+        auto irq = data;
+
+        if(irq > external_global_interrupts_i.size()) {
+            SCCDEBUG(this->name()) << "setie: The interrupt number " << irq << " exceeds the maximum value " << external_global_interrupts_i.size() << " supported by the current configuration";
+        }else {
+            if(is_source_active(irq)) {
+                SCCDEBUG(this->name()) << "enabled interrupt: " << irq;
+
+                auto reg_idx = get_reg_index(irq);
+                auto bit_ofs = get_bit_pos(irq);
+                regs->r_enabled[reg_idx] |= (0x1 << bit_ofs);;
+            }
+        }
+
+        return true;
+    });
+
+    // if the source mode is Level1 or Level0 and the interrupt domain is configured in direct delivery mode
+    // (domaincfg.DM = 0): The pending bit is not cleared by a claim of the interrupt at the APLIC.
+    regs->claim.set_read_cb([this](const scc::sc_register<uint32_t>& reg, uint32_t& data, sc_core::sc_time d) -> bool {
+        data = reg.get();
+        uint8_t source_mode = get_source_mode(regs->r_claim.interruptidentity);
+        if(regs->r_claim > 0) {
+            if(!((source_mode == SourceMode::LEVELHIGH) || (source_mode == SourceMode::LEVELLOW))) {
+                reset_pending_int(regs->r_claim.interruptidentity);
+            }
+        }
+        return true;
+    });
+
+    // on a write to a setie register, for each bit that is one in the 32-bit value written, if that bit position
+    // corresponds to an active interrupt source, the interrupt-enable bit for that source is set to one.
+    regs->enabled.set_write_cb([this](size_t index, scc::sc_register<uint32_t>& reg, uint32_t data) -> bool {
+        return register_enabled_callback(index, reg, data);
+    });
+
+    // if the source mode is Level1 or Level0, The pending bit cannot be set by a write to a setip or setipnum register.
+    regs->pending.set_write_cb([this](size_t index, scc::sc_register<uint32_t>& reg, uint32_t data) -> bool {
+        return register_pending_callback(index, reg, data);
+    });
+
+    // if the source mode is Level1 or Level0, The pending bit is not cleared by a write to an in_clrip register or to clripnum.
+    regs->clrpending.set_write_cb([this](size_t index, scc::sc_register<uint32_t>& reg, uint32_t data) -> bool {
+        return register_clrpending_callback(index, reg, data);
+    });
+
+    // on a write to a clrie register, for each bit that is one in the 32-bit value written, the interrupt-enable
+    // bit for that source is cleared
+    regs->clrenabled.set_write_cb([this](size_t index, scc::sc_register<uint32_t>& reg, uint32_t data) -> bool {
+        return register_clrenabled_callback(index, reg, data);
+    });
+
+    // a read of a clrie register always returns zero.
+    regs->clrenabled.set_read_cb([this](size_t index, const scc::sc_register<uint32_t>& reg, uint32_t& data) -> bool {
+        data = 0;
+        return true;
+    });
+#ifdef SC_SIGNAL_IF
+    SC_METHOD(external_global_interrupts_cb);
+    for(auto& irq : external_global_interrupts_i)
+        sensitive << irq;
+    dont_initialize();
+#else
+    // the number zero is not a valid interrupt identity number at an APLIC.
+    for(auto i = 1; i < external_global_interrupts_i.size(); i++) {
+        external_global_interrupts_i[i].register_nb_transport([this, i](tlm::scc::tlm_signal_gp<bool>& gp, tlm::tlm_phase& p, sc_core::sc_time& t) {
+            this->external_global_interrupts_cb(i, gp.get_value());
+            return tlm::TLM_COMPLETED;
+        });
+    }
+#endif
+
+    // register event callbacks
+    SC_METHOD(reset_cb);
+    sensitive << rst_i;
+    dont_initialize();
+}
+
+aplic::~aplic() = default;
+
+void aplic::reset_cb() {
+    if(rst_i.read())
+        regs->reset_start();
+    else
+        regs->reset_stop();
+}
+
+bool aplic::register_pending_callback(size_t index, scc::sc_register<uint32_t>& reg, uint32_t data)
+{
+    for(uint8_t bit_pos =0 ; bit_pos < REG_SIZE; bit_pos++) {
+            bool value = (data >> bit_pos) & 0x1;
+            if(value) {
+                uint32_t irq = index * REG_SIZE + bit_pos;
+                if(irq > external_global_interrupts_i.size()) {
+                    SCCDEBUG(this->name()) << "setip: The interrupt number " << irq << " exceeds the maximum value " << external_global_interrupts_i.size() << " supported by the current configuration";
+                    continue;
+                }
+                uint8_t source_mode = get_source_mode(irq);
+                if(!((source_mode == SourceMode::LEVELHIGH) || (source_mode == SourceMode::LEVELLOW))) {
+                    if(is_source_active(irq)) {
+                        SCCDEBUG(this->name()) << "set interrupt " << irq << " as pending.";
+                        regs->r_pending[index] |= (0x1 << bit_pos);
+                        handle_pending_int();
+                    }
+                }
+            }
+        }
+    return true;
+}
+
+bool aplic::register_clrpending_callback(size_t index, scc::sc_register<uint32_t>& reg, uint32_t data)
+{
+    for(uint8_t bit_pos =0 ; bit_pos < REG_SIZE; bit_pos++) {
+            bool value = (data >> bit_pos) & 0x1;
+            if(value) {
+                uint32_t irq = index * REG_SIZE + bit_pos;
+                if(irq > external_global_interrupts_i.size()) {
+                    SCCDEBUG(this->name()) << "clrip: The interrupt number " << irq << " exceeds the maximum value " << external_global_interrupts_i.size() << " supported by the current configuration";
+                    continue;
+                }
+                uint8_t source_mode = get_source_mode(irq);
+                if(!((source_mode == SourceMode::LEVELHIGH) || (source_mode == SourceMode::LEVELLOW))) {
+                     bool pending = (regs->r_pending[index] & (0x1 << bit_pos)) ? true : false;
+                    if(is_source_active(irq) && pending) {
+                        SCCDEBUG(this->name()) << "clr pending interrupt: " << irq;
+                        reset_pending_int(irq);
+                    }
+                }
+            }
+        }
+    return true;
+}
+
+bool aplic::register_enabled_callback(size_t index, scc::sc_register<uint32_t>& reg, uint32_t data)
+{
+    for(uint8_t bit_pos =0 ; bit_pos < REG_SIZE; bit_pos++) {
+        bool value = (data >> bit_pos) & 0x1;
+        if(value) {
+            uint32_t irq = index * REG_SIZE + bit_pos;
+            if(irq > external_global_interrupts_i.size()) {
+                SCCDEBUG(this->name()) << "setie: The interrupt number " << irq << " exceeds the maximum value " << external_global_interrupts_i.size() << " supported by the current configuration";
+                continue;
+            }
+
+            if(is_source_active(irq)) {
+                SCCDEBUG(this->name()) << "enabled interrupt: " << irq;
+                regs->r_enabled[index] |= (0x1 << bit_pos);;
+            }
+        }
+    }
+    return true;
+}
+
+bool aplic::register_clrenabled_callback(size_t index, scc::sc_register<uint32_t>& reg, uint32_t data)
+{
+    for(uint8_t bit_pos =0 ; bit_pos < REG_SIZE; bit_pos++) {
+        bool value = (data >> bit_pos) & 0x1;
+        if(value) {
+            uint32_t irq = index * REG_SIZE + bit_pos;
+            if(irq > external_global_interrupts_i.size()) {
+                SCCDEBUG(this->name()) << "clrenabled: The interrupt number " << irq << " exceeds the maximum value " << external_global_interrupts_i.size() << " supported by the current configuration";
+                continue;
+            }
+            SCCDEBUG(this->name()) << "Clear the enable bit for interrupt " << irq;
+            regs->r_enabled[index] &= ~(0x1 << bit_pos);
+        }
+    }
+    return true;
+}
+
+bool aplic::is_source_active(uint32_t index) {
+    uint8_t source_mode = get_source_mode(index);
+
+    if(source_mode == SourceMode::DETACHED || source_mode == SourceMode::EDGERISING || source_mode == SourceMode::EDGEFALLING ||
+    source_mode == SourceMode::LEVELHIGH || source_mode == SourceMode::LEVELLOW) {
+        return true;
+    }else {
+        return false;
+    }
+}
+
+uint8_t aplic::get_source_mode(uint32_t irq)
+{
+    if(irq == 0) {
+        return 0;
+    }
+    return regs->r_sourcecfg[irq - 1];
+}
+
+uint32_t aplic::get_interrupt_priority(uint32_t irq)
+{
+    if(irq == 0) {
+        return 0;
+    }
+
+    return regs->r_targetcfg[irq - 1].interruptpriority;
+}
+
+uint32_t aplic::get_reg_index (uint32_t id) {
+    return (id >> REG_INDEX_SHIFT);
+}
+
+uint32_t aplic::get_bit_pos(uint32_t id) {
+    return (id & BIT_POS_MASK);
+}
+
+#ifdef SC_SIGNAL_IF
+void aplic::external_global_interrupts_cb() {
+    auto handle_pending = false;
+    // set related pending bit if enable is set for incoming global_interrupt
+    for(uint32_t irq = 1; irq < external_global_interrupts_i.size(); irq++) {
+        if(external_global_interrupts_i[irq].event()) {
+            uint32_t value = external_global_interrupts_i[irq].read();
+            external_global_interrupts_handling(irq, value, handle_pending);
+        }
+    }
+
+    if(handle_pending){
+        handle_pending_int();
+    }
+}
+#else
+void aplic::external_global_interrupts_cb(uint32_t irq, uint32_t value) {
+
+    auto handle_pending = false;
+    external_global_interrupts_handling(irq, value, handle_pending);
+
+    if(handle_pending) {
+        handle_pending_int();
+    }
+}
+#endif
+
+bool aplic::external_global_interrupts_handling(uint32_t irq, uint32_t value, bool &handle_pending) {
+
+    SCCDEBUG(this->name()) << "triggered the source interrupt callback for interrupt " << irq << " with value " << value;
+    uint8_t source_mode = get_source_mode(irq);
+    if(source_mode == SourceMode::INACTIVE) {
+        return false;
+    }
+
+    auto reg_idx = get_reg_index(irq);
+    auto bit_ofs = get_bit_pos(irq);
+    bool wire = (value ? true : false);
+
+    uint8_t source_inverted = 0;
+
+    // when configured for a falling edge or low level (mode Level0)
+    // the source is said to be inverted.
+    if((source_mode == SourceMode::EDGEFALLING) || (source_mode == SourceMode::LEVELLOW)) {
+        source_inverted = 1;
+    }
+
+    bool rectified = wire ^ source_inverted;
+
+    SCCDEBUG(this->name()) << "rectified value " << rectified << " using source mode " << static_cast<uint32_t>(source_mode);
+
+    // the pending bit is set to one whenever the rectified input value is high.
+    if(rectified) {
+        regs->r_pending[reg_idx] |= (0x1 << bit_ofs);
+        handle_pending = true;
+    }
+
+
+    // if the source mode is Level1 or Level0 and the interrupt domain is configured in direct delivery mode
+    //(domaincfg.DM = 0): The pending bit is cleared whenever the rectified input value is low.
+    if((source_mode == SourceMode::LEVELHIGH) || (source_mode == SourceMode::LEVELLOW)) {
+        bool pending = (regs->r_pending[reg_idx] & (0x1 << bit_ofs)) ? true : false;
+        if((!rectified) && pending) { //rectified input value is low
+            reset_pending_int(irq);
+        }
+    }
+
+    return handle_pending;
+}
+
+void aplic::handle_pending_int() {
+    auto claim_int = 0U;  // claim interrupt
+    auto claim_prio = 0U; // related priority (highest prio interrupt wins the race)
+    auto raise_int = false;
+    auto thold = regs->r_threshold; // threshold value
+
+    for(size_t irq = 1; irq < external_global_interrupts_i.size(); irq++) {
+        auto reg_idx = get_reg_index(irq);
+        auto bit_ofs = get_bit_pos(irq);
+        auto pending = (regs->r_pending[reg_idx] & (0x1 << bit_ofs)) ? true : false;
+        auto prio = get_interrupt_priority(irq); // read priority value
+        auto enable = (regs->r_enabled[reg_idx] & (0x1 << bit_ofs)) ? true : false;
+
+        // when ITHRESHOLD is a nonzero value P, interrupt sources with priority numbers P and higher do not contribute to signaling 
+        // interrupts to the hart, regardless of the settings of their interrupt-enable bits. When ITHRESHOLD is
+        // zero, all enabled interrupt sources can contribute to signaling interrupts to the hart
+        if(enable && pending && (thold == 0 || prio < thold)) {
+            if(prio > claim_prio) {
+                claim_prio = prio;
+                claim_int = irq;
+                raise_int = true;
+                SCCDEBUG(this->name()) << "pending interrupt " << claim_int << " detected for assert";
+            }
+        }
+    }
+
+    if(raise_int) {
+        // topi is a read-only register whose value indicates the current highest-priority pending-and-enabled
+        // interrupt targeted to this hart that also exceeds the priority threshold specified by ithreshold, if not zero.
+        regs->r_top.interruptpriority = claim_prio;
+        regs->r_top.interruptidentity = claim_int;
+        regs->r_claim.interruptpriority = claim_prio;
+        regs->r_claim.interruptidentity = claim_int;
+        write_irq(true);
+    } else {
+        regs->r_top = 0;
+        regs->r_claim = 0;
+        SCCDEBUG(this->name()) << "no pending interrupt detected for assert.";
+    }
+}
+
+void aplic::reset_pending_int(uint32_t irq) {
+    SCCDEBUG(this->name()) << "triggered the reset pending interrupt for " << irq;
+    // reset related pending bit
+    auto reg_idx = get_reg_index(irq);
+    auto bit_ofs = get_bit_pos(irq);
+    regs->r_pending[reg_idx] &= ~(0x1 << bit_ofs);
+    write_irq(false);
+    // evaluate next pending interrupt
+    handle_pending_int();
+}
+
+void aplic::write_irq(bool irq) {
+    if((regs->r_delivery == 1) && (regs->r_domaincfg.interruptenable == 1)) { //1 = interrupt delivery is enabled
+        if(irq) {
+            SCCDEBUG(this->name()) << "assert aplic interrupt\n";
+        }else{
+            SCCDEBUG(this->name()) << "deassert aplic interrupt\n";
+        }
+    #ifdef SC_SIGNAL_IF
+        core_interrupt_o.write(irq);
+    #else
+        sc_core::sc_time t;
+        tlm::tlm_phase p{tlm::BEGIN_REQ};
+        tlm::scc::tlm_signal_gp<bool> gp;
+        gp.set_value(irq);
+        core_interrupt_o->nb_transport_fw(gp, p, t);
+    #endif
+
+    } else {
+        SCCDEBUG(this->name()) << "Interrupt delivery is disabled because either domaincfg.IE is set to 0, or the delivery register has disabled interrupt delivery to the hart";
+    }
+}
+
+} /* namespace rvi */
+} /* namespace vpvper */

--- a/rvi/aplic.h
+++ b/rvi/aplic.h
@@ -1,0 +1,85 @@
+/*
+ * aplic.h - RISC-V aplic model
+ *
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _APLIC_RISCV_H_
+#define _APLIC_RISCV_H_
+
+#include <scc/register.h>
+#include <scc/tlm_target.h>
+#include <scc/clock_if_mixins.h>
+#ifndef SC_SIGNAL_IF
+#include <tlm/scc/signal_initiator_mixin.h>
+#include <tlm/scc/signal_target_mixin.h>
+#endif
+
+namespace vpvper {
+namespace rvi {
+
+class aplic_regs;
+
+class aplic : public sc_core::sc_module, public scc::tlm_target<> {
+public:
+    enum SourceMode : uint8_t { INACTIVE = 0, DETACHED = 1, EDGERISING = 4, EDGEFALLING = 5, LEVELHIGH = 6, LEVELLOW = 7 };
+    SC_HAS_PROCESS(aplic);
+
+    // the maximum number of interrupt sources an APLIC may support is 1023.
+    cci::cci_param<uint32_t> num_irq {"num_irq", 1023, "Aplic Number of Interrupt"};
+    cci::cci_param<uint32_t> num_irq_prio {"num_irq_prio", 255, "Aplic Number of Interrupt Priority"};
+
+    sc_core::sc_in<bool> rst_i{"rst_i"};
+#ifdef SC_SIGNAL_IF
+    sc_core::sc_out<bool> core_interrupt_o{"core_interrupt_o"};
+    sc_core::sc_vector<sc_core::sc_in<bool>> external_global_interrupts_i;
+#else
+    tlm::scc::tlm_signal_bool_out core_interrupt_o{"core_interrupt_o"};
+    sc_core::sc_vector<tlm::scc::tlm_signal_bool_opt_in> external_global_interrupts_i;
+#endif
+
+
+    aplic(sc_core::sc_module_name nm);
+    virtual ~aplic() override;
+
+    void set_clock_period(sc_core::sc_time period) { clk_period = period; }
+
+protected:
+    void reset_cb();
+
+#ifdef SC_SIGNAL_IF
+    void external_global_interrupts_cb();
+#else
+    void external_global_interrupts_cb(uint32_t irq, uint32_t value);
+#endif
+    bool external_global_interrupts_handling(uint32_t irq, uint32_t value, bool &handle_pending);
+    void write_irq(bool irq);
+    void handle_pending_int();
+    void reset_pending_int(uint32_t irq);
+    bool is_source_active(uint32_t index);
+    uint8_t get_source_mode(uint32_t irq);
+    uint32_t get_interrupt_priority(uint32_t irq);
+    uint32_t get_reg_index (uint32_t id);
+    uint32_t get_bit_pos(uint32_t id);
+    bool register_pending_callback(size_t index, scc::sc_register<uint32_t>& reg, uint32_t data);
+    bool register_clrpending_callback(size_t index, scc::sc_register<uint32_t>& reg, uint32_t data);
+    bool register_enabled_callback(size_t index, scc::sc_register<uint32_t>& reg, uint32_t data);
+    bool register_clrenabled_callback(size_t index, scc::sc_register<uint32_t>& reg, uint32_t data);
+
+    sc_core::sc_time clk_period;
+    std::unique_ptr<aplic_regs> regs;
+    std::function<bool(scc::sc_register<uint32_t>, uint32_t)> m_domaincfg_write_cb;
+
+    static constexpr uint32_t REG_SIZE = 32;
+    static constexpr uint32_t REG_INDEX_SHIFT = 5;
+    static constexpr uint32_t BIT_POS_MASK = 0x1F;
+    static constexpr uint32_t INTERRUPT_PRIO_MASk = 0xFF;
+
+    using aplic_tc = scc::ticking_clock<aplic>;
+    using aplic_tl = scc::tickless_clock<aplic>;
+};
+
+} /* namespace rvi */
+} /* namespace vpvper */
+
+#endif /* _APLIC_RISCV_H_ */

--- a/rvi/aplic.rdl
+++ b/rvi/aplic.rdl
@@ -1,0 +1,84 @@
+addrmap aplic_block {
+    name = "Aplic Project";
+    regfile aplic {
+        reg {
+            name = "domaincfg";
+            desc = "Domain Configuration Register";
+            field {} deliverymode[2:2];
+            field {} interruptenable[8:8];
+        } domaincfg @0;
+        reg {
+            name = "sourcecfg";
+            desc = "Source Configuration Register";
+            field {} sourcemode[2:0];
+        } sourcecfg[1023] @0x4;
+        reg {
+            name = "setip";
+            desc = "Set Interrupt Pending Register";
+            field {} pending[31:0];
+        } setip[32] @0x1C00;
+        reg {
+            name = "setipnum";
+            desc = "Set Interrupt Pending by Number Register";
+            field {} pendingnum[31:0];
+        } setipnum @0x1CDC;
+        reg {
+            name = "in_clrip";
+            desc = "Clear Interrupt Pending Register";
+            field {} clrpending[31:0];
+        } in_clrip[32] @0x1D00;
+        reg {
+            name = "clripnum";
+            desc = "Clear Interrupt Pending by Number Register";
+            field {} clripnum[31:0];
+        } clripnum @0x1DDC;
+        reg {
+            name = "setie";
+            desc = "Set Interrupt Enable Register";
+            field {} enabled[31:0];
+        } setie[32] @0x1E00;
+        reg {
+            name = "setienum";
+            desc = "Set Interrupt Enable by Number Register";
+            field {} enablednum[31:0];
+        } setienum @0x1EDC;
+        reg {
+            name = "clrie";
+            desc = "Clear Interrupt Enable Register";
+            field {} clrenabled[31:0];
+        } clrie[32] @0x1F00;
+        reg {
+            name = "clrienum";
+            desc = "Clear Interrupt Enable by Number Register";
+            field {} clrenablednum[31:0];
+        } clrienum @0x1FDC;
+        reg {
+            name = "target";
+            desc = " Target Register";
+            field {} interruptpriority[7:0];
+        } target[1023] @0x3004;
+        reg {
+            name = "delivery";
+            desc = "Interrupt delivery enable ";
+            field {} delivery[31:0];
+        } idelivery @0x4000;
+        reg {
+            name = "threshold";
+            desc = "Interrupt enable threshold";
+            field {} threshold[31:0];
+        } ithreshold @0x4008;
+        reg {
+            name = "top";
+            desc = "Top interrupt";
+            field {} interruptpriority[7:0];
+            field {} interruptidentity[25:16];
+        } topi @0x4018;
+        reg {
+            name = "claim";
+            desc = "Claim top interrupt";
+            field {} interruptpriority[7:0];
+            field {} interruptidentity[25:16];
+        } claimi @0x401C;
+    };
+    aplic regs @ 0x000;
+};

--- a/rvi/gen/aplic_regs.h
+++ b/rvi/gen/aplic_regs.h
@@ -1,0 +1,139 @@
+/*
+* Copyright (c) 2023 - 2025 MINRES Technologies GmbH
+*
+* SPDX-License-Identifier: Apache-2.0
+*
+* Generated at 2025-12-23 11:13:45 UTC 
+* by peakrdl_mnrs version 1.2.10
+*/
+
+#ifndef _APLIC_H_
+#define _APLIC_H_
+
+#include <scc/register.h>
+#include <scc/tlm_target.h>
+#include <scc/utilities.h>
+#include <util/bit_field.h>
+
+namespace vpvper {
+namespace rvi {
+
+class aplic_regs : public sc_core::sc_module, public scc::resetable {
+public:
+    //////////////////////////////////////////////////////////////////////////////
+    // storage declarations
+    //////////////////////////////////////////////////////////////////////////////
+        BEGIN_BF_DECL(domaincfg_t, uint32_t);
+        BF_FIELD(deliverymode, 2, 1);
+        BF_FIELD(interruptenable, 8, 1);
+        END_BF_DECL() r_domaincfg;
+    
+        BEGIN_BF_DECL(sourcecfg_t, uint32_t);
+        BF_FIELD(sourcemode, 0, 3);
+        END_BF_DECL();
+        std::array<sourcecfg_t, 1023> r_sourcecfg; 
+    
+        std::array<uint32_t, 32> r_pending; 
+    
+        uint32_t r_pendingnum;
+    
+        std::array<uint32_t, 32> r_clrpending; 
+    
+        uint32_t r_clripnum;
+    
+        std::array<uint32_t, 32> r_enabled; 
+    
+        uint32_t r_enablednum;
+    
+        std::array<uint32_t, 32> r_clrenabled; 
+    
+        uint32_t r_clrenablednum;
+    
+        BEGIN_BF_DECL(targetcfg_t, uint32_t);
+        BF_FIELD(interruptpriority, 0, 8);
+        END_BF_DECL();
+        std::array<targetcfg_t, 1023> r_targetcfg; 
+    
+        uint32_t r_delivery;
+    
+        uint32_t r_threshold;
+    
+        BEGIN_BF_DECL(top_t, uint32_t);
+        BF_FIELD(interruptpriority, 0, 8);
+        BF_FIELD(interruptidentity, 16, 10);
+        END_BF_DECL() r_top;
+    
+        BEGIN_BF_DECL(claim_t, uint32_t);
+        BF_FIELD(interruptpriority, 0, 8);
+        BF_FIELD(interruptidentity, 16, 10);
+        END_BF_DECL() r_claim;
+    
+
+    //////////////////////////////////////////////////////////////////////////////
+    // register declarations
+    //////////////////////////////////////////////////////////////////////////////
+    
+        scc::sc_register<domaincfg_t> domaincfg;
+            scc::sc_register_indexed<sourcecfg_t, 1023> sourcecfg; 
+            scc::sc_register_indexed<uint32_t, 32> pending; 
+        scc::sc_register<uint32_t> pendingnum;
+            scc::sc_register_indexed<uint32_t, 32> clrpending; 
+        scc::sc_register<uint32_t> clripnum;
+            scc::sc_register_indexed<uint32_t, 32> enabled; 
+        scc::sc_register<uint32_t> enablednum;
+            scc::sc_register_indexed<uint32_t, 32> clrenabled; 
+        scc::sc_register<uint32_t> clrenablednum;
+            scc::sc_register_indexed<targetcfg_t, 1023> targetcfg; 
+        scc::sc_register<uint32_t> delivery;
+        scc::sc_register<uint32_t> threshold;
+        scc::sc_register<top_t> top;
+        scc::sc_register<claim_t> claim;
+
+    aplic_regs(sc_core::sc_module_name nm);
+
+    template <unsigned BUSWIDTH = 32> void registerResources(scc::tlm_target<BUSWIDTH> &target);
+};
+
+
+//////////////////////////////////////////////////////////////////////////////
+// member functions
+//////////////////////////////////////////////////////////////////////////////
+
+inline aplic_regs::aplic_regs(sc_core::sc_module_name nm)
+: sc_core::sc_module(nm)
+, NAMED(domaincfg, r_domaincfg, 0, *this)
+, NAMED(sourcecfg, r_sourcecfg, 0, *this)
+, NAMED(pending, r_pending, 0, *this)
+, NAMED(pendingnum, r_pendingnum, 0, *this)
+, NAMED(clrpending, r_clrpending, 0, *this)
+, NAMED(clripnum, r_clripnum, 0, *this)
+, NAMED(enabled, r_enabled, 0, *this)
+, NAMED(enablednum, r_enablednum, 0, *this)
+, NAMED(clrenabled, r_clrenabled, 0, *this)
+, NAMED(clrenablednum, r_clrenablednum, 0, *this)
+, NAMED(targetcfg, r_targetcfg, 0, *this)
+, NAMED(delivery, r_delivery, 0, *this)
+, NAMED(threshold, r_threshold, 0, *this)
+, NAMED(top, r_top, 0, *this)
+, NAMED(claim, r_claim, 0, *this) {}
+
+template <unsigned BUSWIDTH> inline void aplic_regs::registerResources(scc::tlm_target<BUSWIDTH> &target) {
+    target.addResource(domaincfg, 0x0UL);
+    target.addResource(sourcecfg, 0x4UL);
+    target.addResource(pending, 0x1c00UL);
+    target.addResource(pendingnum, 0x1cdcUL);
+    target.addResource(clrpending, 0x1d00UL);
+    target.addResource(clripnum, 0x1ddcUL);
+    target.addResource(enabled, 0x1e00UL);
+    target.addResource(enablednum, 0x1edcUL);
+    target.addResource(clrenabled, 0x1f00UL);
+    target.addResource(clrenablednum, 0x1fdcUL);
+    target.addResource(targetcfg, 0x3004UL);
+    target.addResource(delivery, 0x4000UL);
+    target.addResource(threshold, 0x4008UL);
+    target.addResource(top, 0x4018UL);
+    target.addResource(claim, 0x401cUL);
+}
+}//namespace rvi
+}//namespace vpvper
+#endif // _APLIC_H_


### PR DESCRIPTION
 Aplic model  description:

- This model supports only the Direct delivery mode.
- It has been tested for a single hart (index:0) implementing only M-mode, with a single machine-level interrupt domain for that hart, and for level-triggered interrupts using source and target TLM signals.
 - It also supports edge-triggered interrupts and SystemC signals, however, these features have not yet been validated.
 - Additionally, functionality for the pendingnum, clripnum registers behavior is not implemented.


register file generation:
 - peakrdl mnrs --regfiles -o output rvi/aplic.rdl
 - cp output/gen/aplic_regs.h rvi/gen
