### PR TITLE
Add TLM signal support to aclint for interrupts

### DIFF
--- a/minres/aclint.cpp
+++ b/minres/aclint.cpp
@@ -79,7 +79,15 @@ void aclint::reset_cb() {
 void aclint::write_irq() {
     while(irq_val.has_next()) {
         auto v = irq_val.get();
-        msip_int_o[v >> 1].write(v & 0x1);
+#ifdef SC_SIGNAL_IF
+         msip_int_o[v >> 1].write(v & 0x1);
+#else
+        sc_core::sc_time t;
+        tlm::tlm_phase p{tlm::BEGIN_REQ};
+        tlm::scc::tlm_signal_gp<bool> gp;
+        gp.set_value(v & 0x1);
+        msip_int_o[v >> 1]->nb_transport_fw(gp, p, t);
+#endif
     }
 }
 
@@ -98,7 +106,15 @@ void aclint::update_mtime() {
         for(auto i = 0u; i < regs->mtimecmp.size(); ++i) {
             // check for and handle interrupts
             uint64_t smallest = std::numeric_limits<uint64_t>::max();
-            mtime_int_o[i].write(regs->r_mtimecmp[i] <= regs->r_mtime);
+#ifdef SC_SIGNAL_IF
+             mtime_int_o[i].write(regs->r_mtimecmp[i] <= regs->r_mtime);
+#else
+            sc_core::sc_time t;
+            tlm::tlm_phase p{tlm::BEGIN_REQ};
+            tlm::scc::tlm_signal_gp<bool> gp;
+            gp.set_value(regs->r_mtimecmp[i] <= regs->r_mtime);
+            mtime_int_o[i]->nb_transport_fw(gp, p, t);
+#endif
             mtimecmp_min = std::min(mtimecmp_min, regs->r_mtimecmp[i]);
         }
         // calculate next invocation

--- a/minres/aclint.h
+++ b/minres/aclint.h
@@ -11,6 +11,10 @@
 #include <scc/signal_opt_ports.h>
 #include <scc/tlm_target.h>
 #include <sysc/communication/sc_signal_ports.h>
+#ifndef SC_SIGNAL_IF
+#include <tlm/scc/signal_initiator_mixin.h>
+#include <tlm/scc/tlm_signal.h>
+#endif
 
 namespace vpvper {
 namespace minres {
@@ -21,8 +25,13 @@ class aclint : public sc_core::sc_module, public scc::tlm_target<> {
 public:
     sc_core::sc_in<sc_core::sc_time> mtime_clk_i{"mtime_clk_i"};
     sc_core::sc_in<bool> rst_i{"rst_i"};
-    sc_core::sc_vector<sc_core::sc_out<bool>> mtime_int_o;
-    sc_core::sc_vector<sc_core::sc_out<bool>> msip_int_o;
+#ifdef SC_SIGNAL_IF
+     sc_core::sc_vector<sc_core::sc_out<bool>> mtime_int_o;
+     sc_core::sc_vector<sc_core::sc_out<bool>> msip_int_o;
+#else
+    sc_core::sc_vector<tlm::scc::tlm_signal_bool_out> mtime_int_o;
+    sc_core::sc_vector<tlm::scc::tlm_signal_bool_out> msip_int_o;
+#endif
     scc::sc_out_opt<uint64_t> mtime_o;
     aclint(sc_core::sc_module_name nm, size_t num_cpus = 1);
     virtual ~aclint();


### PR DESCRIPTION
Added a compile-time option to use tlm::scc::tlm_signal_bool_out for the software and timer interrupts in the aclint model.