### PR TITLE
Change find_package for elfio to QUIET

### DIFF
--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -14,7 +14,7 @@ if(TARGET Seasocks::seasocks)
     set(SEASOCKS_LIB Seasocks::seasocks)
 endif()
 
-find_package(elfio REQUIRED)
+find_package(elfio QUIET)
 
 add_library(${PROJECT_NAME}_generic terminal.cpp ${WEBSOCKET_SRC} spi_mem.cpp)
 if(LINUX) 


### PR DESCRIPTION
Changing the find_package on elfio from REQUIRED to QUIET to prevent make errors in build environments that don't use Conan.