### PR TITLE
Add a RISC-V PLIC model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             -DBUILD_TESTING=ON
 
       - name: Build
-        run: cmake --build build --target vpvper_sifive test_clint_timer
+        run: cmake --build build --target vpvper_sifive test_clint_timer vpvper_rvi test_plic
 
       - name: Run tests
         run: ctest --test-dir build --output-on-failure

--- a/rvi/CMakeLists.txt
+++ b/rvi/CMakeLists.txt
@@ -22,6 +22,10 @@ endif()
 target_link_libraries(${PROJECT_NAME}_rvi PUBLIC ${PROJECT_NAME}_generic scc)
 add_library(${PROJECT_NAME}::rvi ALIAS ${PROJECT_NAME}_rvi)
 
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
+
 install(TARGETS ${PROJECT_NAME}_rvi COMPONENT ${PROJECT_NAME}_rvi
   EXPORT ${PROJECT_NAME}_genericTargets                         # for downstream dependencies
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/rvi/gen/plic_regs.h
+++ b/rvi/gen/plic_regs.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) MINRES Technologies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _RVI_PLIC_REGS_H_
+#define _RVI_PLIC_REGS_H_
+
+#include <stdint.h>
+
+#include <array>
+#include <vector>
+
+#include <scc/register.h>
+#include <scc/tlm_target.h>
+#include <scc/utilities.h>
+#include <util/bit_field.h>
+
+namespace vpvper {
+namespace rvi {
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+class plic_regs : public sc_core::sc_module, public scc::resetable {
+   public:
+    static constexpr uint32_t NUM_PENDING = (NUM_SOURCES + 31) / 32;
+    static constexpr uint32_t NUM_ENABLED = NUM_PENDING;
+
+    using Reg32 = scc::sc_register<uint32_t>;
+    using EnReg = scc::sc_register_indexed<uint32_t, NUM_ENABLED>;
+
+    // storage declarations
+    std::array<uint32_t, NUM_SOURCES> r_priority;
+    std::array<uint32_t, NUM_PENDING> r_pending;
+    std::array<std::array<uint32_t, NUM_ENABLED>, NUM_CONTEXTS> r_enabled;
+    std::array<uint32_t, NUM_CONTEXTS> r_threshold;
+    std::array<uint32_t, NUM_CONTEXTS> r_claim_complete;
+
+    // register declarations
+    scc::sc_register_indexed<uint32_t, NUM_SOURCES> priority;
+    scc::sc_register_indexed<uint32_t, NUM_PENDING> pending;
+    std::vector<std::unique_ptr<EnReg>> enabled;
+    std::vector<std::unique_ptr<Reg32>> threshold;
+    std::vector<std::unique_ptr<Reg32>> claim_complete;
+
+    plic_regs(sc_core::sc_module_name nm);
+
+    template <unsigned BUSWIDTH = 32>
+    void registerResources(scc::tlm_target<BUSWIDTH>& target);
+};
+
+//////////////////////////////////////////////////////////////////////////////
+// member functions
+//////////////////////////////////////////////////////////////////////////////
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+plic_regs<NUM_SOURCES, NUM_CONTEXTS>::plic_regs(sc_core::sc_module_name nm)
+    : sc_core::sc_module(nm),
+      NAMED(priority, r_priority, 0, *this),
+      NAMED(pending, r_pending, 0, *this, UINT32_MAX, 0) {
+    for (uint32_t i = 0; i < NUM_CONTEXTS; ++i) {
+        auto nm_str = "enabled" + std::to_string(i);
+        enabled.emplace_back(std::make_unique<EnReg>(nm_str.c_str(), r_enabled[i], 0, *this));
+        nm_str = "threshold" + std::to_string(i);
+        threshold.emplace_back(std::make_unique<Reg32>(nm_str.c_str(), r_threshold[i], 0, *this));
+        nm_str = "claim_complete" + std::to_string(i);
+        claim_complete.emplace_back(std::make_unique<Reg32>(nm_str.c_str(), r_claim_complete[i], 0, *this));
+    }
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+template <unsigned BUSWIDTH>
+inline void plic_regs<NUM_SOURCES, NUM_CONTEXTS>::registerResources(scc::tlm_target<BUSWIDTH>& target) {
+    target.addResource(priority, 0x0UL);
+    target.addResource(pending, 0x1000UL);
+    for (uint32_t i = 0; i < NUM_CONTEXTS; ++i) {
+        target.addResource(*enabled[i], 0x2000UL + (0x80UL * i));
+        target.addResource(*threshold[i], 0x200000UL + (0x1000UL * i));
+        target.addResource(*claim_complete[i], 0x200004UL + (0x1000UL * i));
+    }
+}
+
+}  // namespace rvi
+}  // namespace vpvper
+
+#endif  // _RVI_PLIC_REGS_H_

--- a/rvi/plic.h
+++ b/rvi/plic.h
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) MINRES Technologies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _RVI_PLIC_H_
+#define _RVI_PLIC_H_
+
+#include <algorithm>
+
+#include <scc/register.h>
+#include <scc/tlm_target.h>
+#ifndef SC_SIGNAL_IF
+#include <tlm/scc/signal_initiator_mixin.h>
+#include <tlm/scc/signal_target_mixin.h>
+#endif
+
+#include "gen/plic_regs.h"
+
+namespace vpvper {
+namespace rvi {
+
+/**
+ * @brief RISC-V Platform-Level Interrupt Controller (PLIC) SystemC/TLM model.
+ *
+ * Implements the RISC-V PLIC specification as a synthesizable SystemC module.
+ * Accepts up to NUM_SOURCES interrupt inputs and drives one interrupt
+ * output per context (hart). Interrupt arbitration follows priority ordering
+ * with per-context threshold filtering; the lowest source ID wins ties.
+ *
+ * The standard claim/complete handshake is modeled via register callbacks:
+ * reading the claim/complete register returns and atomically clears the
+ * highest-priority pending interrupt; writing it signals completion and
+ * allows the source to fire again.
+ *
+ * @tparam NUM_SOURCES  Number of interrupt sources representng interrupt IDs 1..NUM_SOURCES.
+ *                      Source 0 is reserved and unused per the PLIC specification.
+ * @tparam NUM_CONTEXTS Number of interrupt contexts (typically one per hart).
+ */
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+class plic : public sc_core::sc_module, public scc::tlm_target<> {
+   public:
+    SC_HAS_PROCESS(plic);  // NOLINT
+
+    sc_core::sc_in<sc_core::sc_time> clk_i{"clk_i"};
+    sc_core::sc_in<bool> rst_i{"rst_i"};
+
+#ifdef SC_SIGNAL_IF
+    sc_core::sc_vector<sc_core::sc_in<bool>> interrupts_i;
+    sc_core::sc_vector<sc_core::sc_out<bool>> interrupts_o;
+#else
+    sc_core::sc_vector<tlm::scc::tlm_signal_bool_opt_in> interrupts_i;
+    sc_core::sc_vector<tlm::scc::tlm_signal_bool_out> interrupts_o;
+#endif
+
+    plic(sc_core::sc_module_name nm);
+    ~plic() override;
+
+   protected:
+    /**
+     * @brief SC_METHOD sensitive to clk_i; captures the current clock period.
+     *
+     * Stores the value read from clk_i into the internal @ref clk member so
+     * that the TLM target base class always has an up-to-date clock reference.
+     */
+    void clock_cb();
+
+    /**
+     * @brief SC_METHOD sensitive to rst_i; drives the register block reset.
+     *
+     * Calls regs->reset_start() while rst_i is asserted and regs->reset_stop()
+     * once it is de-asserted.
+     */
+    void reset_cb();
+
+#ifdef SC_SIGNAL_IF
+    /**
+     * @brief SC_METHOD triggered on any rising edge of interrupts_i (sc_signal build).
+     *
+     * Walks all interrupt sources, sets the pending bit for every source that
+     * has transitioned high and has been cleared, then calls handle_pending_irq()
+     * for every context.
+     */
+    void source_irq_cb();
+#else
+    /**
+     * @brief TLM nb_transport callback invoked when a source interrupt changes (TLM build).
+     *
+     * Sets the pending bit for the specified source when it asserts and has
+     * been cleared, then calls handle_pending_irq() for every context.
+     *
+     * @param irq_idx Source interrupt index (0 corresponds to source ID 1).
+     * @param value   New value driven by the source (non-zero = asserted).
+     */
+    void source_irq_cb(uint32_t irq_idx, uint32_t value);
+#endif
+
+    /**
+     * @brief Evaluate pending interrupts for a context and assert the core IRQ if needed.
+     *
+     * Checks whether any enabled, pending source interrupt above the context
+     * threshold exists. If one is found, the interrupt output is asserted.
+     * If not, the interrupt output is de-asserted.
+     *
+     * @param ctx Context index to evaluate (0-based).
+     */
+    void handle_pending_irq(uint32_t ctx);
+
+    /**
+     * @brief Read callback for the claim/complete register of a context.
+     *
+     * Finds the highest-priority pending interrupt ID for @p ctx and clears
+     * its pending bit, implementing the atomic claim operation defined by the
+     * PLIC specification.
+     *
+     * @param ctx         Context index performing the claim (0-based).
+     * @param[out] src_id Filled with the claimed interrupt source ID, or 0 if none.
+     */
+    void claim_complete_read_cb(uint32_t ctx, uint32_t& src_id);
+
+    /**
+     * @brief Write callback for the claim/complete register of a context.
+     *
+     * Signals that the interrupt identified by @p src_id has been serviced and
+     * marks the source as cleared so it can fire again. Writes for source ID 0
+     * (reserved) and for disabled sources are silently ignored.
+     *
+     * @param ctx Context index completing the interrupt (0-based).
+     * @param src_id Interrupt source ID being completed.
+     */
+    void claim_complete_write_cb(uint32_t ctx, uint32_t src_id);
+
+    /**
+     * @brief Drive the core interrupt output for a context.
+     *
+     * Abstracts the sc_signal / TLM signal interface difference and writes
+     * @p value to interrupts_o[ctx].
+     *
+     * @param ctx   Context index whose interrupt output is to be driven (0-based).
+     * @param value Value to drive: true = assert, false = de-assert.
+     */
+    void write_irq(uint32_t ctx, bool value);
+
+    /**
+     * @brief Find a candidate pending interrupt for a context.
+     *
+     * Scans all interrupt sources for one that is pending, enabled for @p ctx,
+     * and has priority strictly above the context threshold.
+     *
+     * When @p find_top_priority is true the full source list is scanned and
+     * the highest-priority (lowest source ID on a tie) interrupt ID is returned.
+     * When false the scan stops at the first qualifying source, which is
+     * sufficient for deciding whether an interrupt should be raised.
+     *
+     * @param ctx               Context index to evaluate (0-based).
+     * @param find_top_priority True to return the highest-priority source ID;
+     *                          false to return any qualifying source ID.
+     * @param ignore_threshold  True to ignore the threshold value during the search;
+     *                          false to take threshold into account.
+     * @return Source interrupt ID of the selected interrupt, or 0 if none qualifies.
+     */
+    uint32_t get_source_irq(uint32_t ctx, bool find_top_priority, bool ignore_threshold) const;
+
+    /**
+     * @brief Return a reference to the pending register value that contains @p src_id.
+     *
+     * The PLIC pending state is stored as a flat array of 32-bit words; this
+     * helper returns the word for the given interrupt source ID so callers can
+     * test or modify individual bits.
+     *
+     * @param src_id Interrupt source ID whose pending word is required.
+     * @return       Reference to the 32-bit pending register containing the bit for @p src_id.
+     */
+    uint32_t& get_pending(uint32_t src_id) const;
+
+    /**
+     * @brief Convert a zero-based source interrupt vector index to a PLIC source ID.
+     *
+     * The PLIC reserves source ID 0 as "no interrupt", so the first real interrupt
+     * source (index 0 in the interrupt vector) maps to PLIC source ID 1.  This
+     * helper encapsulates that offset so callers never hard-code the adjustment.
+     *
+     * @param src_idx Zero-based index into the source interrupt vector.
+     * @return        PLIC source ID corresponding to @p src_idx (always >= 1).
+     */
+    uint32_t get_source_id(uint32_t src_idx) const;
+
+    sc_core::sc_time clk;
+    std::unique_ptr<plic_regs<NUM_SOURCES, NUM_CONTEXTS>> regs;
+    std::array<bool, NUM_SOURCES> src_irq_cleared;
+};
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+plic<NUM_SOURCES, NUM_CONTEXTS>::plic(sc_core::sc_module_name nm)
+    : sc_core::sc_module(nm),
+      tlm_target<>(clk),
+      interrupts_i("interrupts_i", NUM_SOURCES),
+      interrupts_o("interrupts_o", NUM_CONTEXTS)
+
+{
+    src_irq_cleared.fill(true);
+
+    regs = std::make_unique<plic_regs<NUM_SOURCES, NUM_CONTEXTS>>("regs");
+    regs->registerResources(*this);
+    // register per-context claim/complete write callbacks
+    for (uint32_t i = 0; i < NUM_CONTEXTS; ++i) {
+        regs->claim_complete[i]->set_read_cb(
+            [this, i](const scc::sc_register<uint32_t>& reg, uint32_t& v, sc_core::sc_time& d) -> bool {
+                claim_complete_read_cb(i, v);
+                return true;
+            });
+        regs->claim_complete[i]->set_write_cb(
+            [this, i](scc::sc_register<uint32_t>& reg, const uint32_t& v, sc_core::sc_time& d) -> bool {
+                claim_complete_write_cb(i, v);
+                return true;
+            });
+    }
+
+    // port callbacks
+#ifdef SC_SIGNAL_IF
+    SC_METHOD(source_irq_cb);
+    for (auto& irq : interrupts_i) sensitive << irq.pos();
+    dont_initialize();
+#else
+    for (uint32_t i = 0; i < interrupts_i.size(); ++i) {
+        interrupts_i[i].register_nb_transport(
+            [this, i](tlm::scc::tlm_signal_gp<bool>& gp, tlm::tlm_phase& p, sc_core::sc_time& t) {
+                this->source_irq_cb(i, gp.get_value());
+                return tlm::TLM_COMPLETED;
+            });
+    }
+#endif
+
+    // register event callbacks
+    SC_METHOD(clock_cb);
+    sensitive << clk_i;
+    SC_METHOD(reset_cb);
+    sensitive << rst_i;
+    dont_initialize();
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+plic<NUM_SOURCES, NUM_CONTEXTS>::~plic() {}  // NOLINT
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+void plic<NUM_SOURCES, NUM_CONTEXTS>::clock_cb() {
+    this->clk = clk_i.read();
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+void plic<NUM_SOURCES, NUM_CONTEXTS>::reset_cb() {
+    if (rst_i.read())
+        regs->reset_start();
+    else
+        regs->reset_stop();
+}
+
+#ifdef SC_SIGNAL_IF
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+void plic<NUM_SOURCES, NUM_CONTEXTS>::source_irq_cb() {
+    auto handle_pending = false;
+    for (auto i = 0UL; i < interrupts_i.size(); ++i) {
+        if (src_irq_cleared[i] && (interrupts_i[i].read() == 1)) {
+            const auto src_id = get_source_id(i);
+            const auto bit_ofs = src_id & 0x1F;
+            get_pending(src_id) |= (0x1UL << bit_ofs);
+            src_irq_cleared[i] = false;
+            handle_pending = true;
+            SCCDEBUG(this->name()) << "Setting interrupt " << src_id << " as pending";
+        }
+    }
+
+    if (handle_pending) {
+        for (auto i = 0UL; i < NUM_CONTEXTS; ++i) {
+            handle_pending_irq(i);
+        }
+    }
+}
+#else
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+void plic<NUM_SOURCES, NUM_CONTEXTS>::source_irq_cb(uint32_t irq_idx, uint32_t value) {
+    if (!src_irq_cleared[irq_idx] || !value) {
+        // If the source interrupt has not been cleared or the interrupt isn't high, do nothing
+        return;
+    }
+
+    // Set the source's pending interrupt bit
+    const auto src_id = get_source_id(irq_idx);
+    const auto bit_ofs = src_id & 0x1F;
+    get_pending(src_id) |= (0x1UL << bit_ofs);
+    src_irq_cleared[irq_idx] = false;
+    SCCDEBUG(this->name()) << "Setting interrupt " << src_id << " as pending";
+
+    // Check if any contexts need interrupts
+    for (auto i = 0UL; i < NUM_CONTEXTS; ++i) {
+        handle_pending_irq(i);
+    }
+}
+#endif
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+void plic<NUM_SOURCES, NUM_CONTEXTS>::handle_pending_irq(uint32_t ctx) {
+    if (get_source_irq(ctx, false, false)) {
+        // If any pending interrupt passes the threshold test and an interrupt is not already active, trigger one
+        SCCDEBUG(this->name()) << "Context " << ctx << " sending interrupt";
+        write_irq(ctx, true);
+    } else {
+        // If there are no pending source interrupts that pass the threshold test, the interrupt can be deactivated
+        write_irq(ctx, false);
+        SCCDEBUG(this->name()) << "Context " << ctx << " has no further pending interrupts";
+    }
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+void plic<NUM_SOURCES, NUM_CONTEXTS>::claim_complete_read_cb(uint32_t ctx, uint32_t& src_id) {
+    // Reading the claim/complete register returns the ID of the highest priority pending interrupt and clears that
+    // source's interrupt pending bit. The claim operation is not affected by the threshold setting.
+    src_id = get_source_irq(ctx, true, false);
+    regs->r_claim_complete[ctx] = src_id;
+    const auto bit_ofs = src_id & 0x1F;
+    get_pending(src_id) &= ~(0x1u << bit_ofs);
+    SCCTRACE(this->name()) << "Context " << ctx << " claimed interrupt " << src_id;
+
+    // After clearing the highest priority interrupt's pending bit, handle any remaining pending interrupts.
+    // This might cause the output interrupt to de-assert if there are no pending interrupts that are serviceable,
+    // or the output interrupt might remain asserted if there are.
+    handle_pending_irq(ctx);
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+void plic<NUM_SOURCES, NUM_CONTEXTS>::claim_complete_write_cb(uint32_t ctx, uint32_t src_id) {
+    if (src_id == 0) {
+        // Interrupt 0 is unused/reserved
+        SCCTRACE(this->name()) << "Context " << ctx << " ignoring claim completion for interrupt 0";
+        return;
+    }
+
+    // If the source interrupt is disabled, ignore the claim completion
+    const auto reg_idx = src_id >> 5;
+    const auto bit_ofs = src_id & 0x1F;
+    const bool enabled = (regs->r_enabled[ctx][reg_idx] >> bit_ofs) & 1u;
+    if (!enabled) {
+        SCCTRACE(this->name()) << "Context " << ctx << " ignoring claim completion for disabled source " << src_id;
+        return;
+    }
+
+    // Writing the claim/complete register signals completion of the interrupt ID written.
+    // The source interrupt can now be triggered again.
+    SCCTRACE(this->name()) << "Context " << ctx << " claim complete for interrupt " << src_id;
+    src_irq_cleared[src_id - 1] = true;  // Source cleared array does not include an entry for unused source 0
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+void plic<NUM_SOURCES, NUM_CONTEXTS>::write_irq(uint32_t ctx, bool value) {
+#ifdef SC_SIGNAL_IF
+    interrupts_o[ctx].write(value);
+#else
+    sc_core::sc_time t;
+    tlm::tlm_phase p{tlm::BEGIN_REQ};
+    tlm::scc::tlm_signal_gp<bool> gp;
+    gp.set_value(value);
+    interrupts_o[ctx]->nb_transport_fw(gp, p, t);
+#endif
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+uint32_t plic<NUM_SOURCES, NUM_CONTEXTS>::get_source_irq(uint32_t ctx, bool find_top_priority,
+                                                         bool ignore_threshold) const {
+    auto prio_irq = 0U;
+    auto top_prio = 0U;
+    const auto thold = regs->r_threshold[ctx];
+
+    // Walk through each interrupt source and check for pending interrupts
+    for (auto i = 0UL; i < interrupts_i.size(); ++i) {
+        const auto src_id = get_source_id(i);
+        const auto reg_idx = src_id >> 5;
+        const auto bit_ofs = src_id & 0x1F;
+        const bool pending = (get_pending(src_id) >> bit_ofs) & 1u;
+        const bool enabled = (regs->r_enabled[ctx][reg_idx] >> bit_ofs) & 1u;
+        const auto prio = regs->r_priority[src_id];
+
+        if (pending && enabled && (ignore_threshold || (prio > thold))) {
+            // Lowest source ID wins in case of equal priority
+            if (prio > top_prio) {
+                top_prio = prio;
+                prio_irq = src_id;
+                if (!find_top_priority) {
+                    // If we don't need the top priority interrupt, we can stop here
+                    SCCDEBUG(this->name()) << "Context " << ctx << " found pending interrupt " << src_id;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (find_top_priority) {
+        SCCDEBUG(this->name()) << "Context " << ctx << " top priority pending interrupt is " << prio_irq;
+    }
+
+    return prio_irq;
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+uint32_t& plic<NUM_SOURCES, NUM_CONTEXTS>::get_pending(uint32_t src_id) const {
+    const auto reg_idx = src_id >> 5;
+    return regs->r_pending[reg_idx];
+}
+
+template <uint32_t NUM_SOURCES, uint32_t NUM_CONTEXTS>
+uint32_t plic<NUM_SOURCES, NUM_CONTEXTS>::get_source_id(uint32_t src_idx) const {
+    // Source interrupt 0 is not valid on the PLIC, so index 0 of the source interrupt vector corresponds to ID 1
+    return src_idx + 1;
+}
+
+}  // namespace rvi
+}  // namespace vpvper
+
+#endif  // _RVI_PLIC_H_

--- a/rvi/test/CMakeLists.txt
+++ b/rvi/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+# Copyright (c) MINRES Technologies GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+cmake_minimum_required(VERSION 3.12)
+
+add_executable(test_plic test_plic.cpp)
+target_link_libraries(test_plic PRIVATE ${PROJECT_NAME}_rvi)
+add_test(NAME plic_functionality COMMAND test_plic)

--- a/rvi/test/test_plic.cpp
+++ b/rvi/test/test_plic.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) MINRES Technologies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SystemC testbench for vpvper::rvi::plic<NUM_SOURCES, NUM_CONTEXTS>.
+ *
+ * Exercises: basic delivery, claim/complete protocol, threshold filtering,
+ * priority arbitration, context isolation, multiple-pending queuing, reset,
+ * and the interrupt index-to-source-ID mapping.
+ */
+
+#define SC_INCLUDE_DYNAMIC_PROCESSES
+#include <iostream>
+#include <systemc>
+#include <tlm>
+#include <tlm_utils/simple_initiator_socket.h>
+#include <scc/report.h>
+#ifndef SC_SIGNAL_IF
+#include <tlm/scc/signal_initiator_mixin.h>
+#include <tlm/scc/signal_target_mixin.h>
+#include <tlm/scc/tlm_signal.h>
+#endif
+
+#include "rvi/plic.h"
+
+static constexpr uint32_t NS = 8;
+static constexpr uint32_t NC = 2;
+using Plic = vpvper::rvi::plic<NS, NC>;
+
+// Register address helpers
+static constexpr uint64_t PRIO(uint32_t s)    { return 0x0000UL + s * 4; }
+static constexpr uint64_t PENDING(uint32_t i) { return 0x1000UL + i * 4; }
+static constexpr uint64_t ENABLE(uint32_t c)  { return 0x2000UL + c * 0x80UL; }
+static constexpr uint64_t THRESH(uint32_t c)  { return 0x200000UL + c * 0x1000UL; }
+static constexpr uint64_t CLAIM(uint32_t c)   { return 0x200004UL + c * 0x1000UL; }
+
+struct TestBench : sc_core::sc_module {
+    SC_HAS_PROCESS(TestBench); // NOLINT
+
+    sc_core::sc_signal<sc_core::sc_time> clk_sig{"clk"};
+    sc_core::sc_signal<bool>             rst_sig{"rst"};
+    Plic                                 dut{"dut"};
+    tlm_utils::simple_initiator_socket<TestBench, 0> isock{"isock"};
+
+#ifdef SC_SIGNAL_IF
+    sc_core::sc_vector<sc_core::sc_signal<bool>> irq_src{"irq_src", NS};
+    sc_core::sc_vector<sc_core::sc_signal<bool>> irq_out{"irq_out", NC};
+#else
+    sc_core::sc_vector<tlm::scc::tlm_signal_bool_out> irq_src{"irq_src", NS};
+    sc_core::sc_vector<tlm::scc::tlm_signal_bool_in>  irq_out{"irq_out", NC};
+    std::array<bool, NC> ctx_irq{};
+#endif
+
+    int failures{0};
+
+    TestBench(sc_core::sc_module_name nm)
+    : sc_core::sc_module(nm) {
+        dut.clk_i(clk_sig);
+        dut.rst_i(rst_sig);
+
+        for (uint32_t i = 0; i < NS; ++i) {
+#ifdef SC_SIGNAL_IF
+            dut.interrupts_i[i](irq_src[i]);
+#else
+            irq_src[i](dut.interrupts_i[i]);
+#endif
+        }
+        for (uint32_t i = 0; i < NC; ++i) {
+            dut.interrupts_o[i](irq_out[i]);
+#ifndef SC_SIGNAL_IF
+            const auto idx = i;
+            irq_out[i].register_nb_transport(
+                [this, idx](tlm::scc::tlm_signal_gp<bool>& gp,
+                            tlm::tlm_phase&, sc_core::sc_time&) -> tlm::tlm_sync_enum {
+                    ctx_irq[idx] = gp.get_value();
+                    return tlm::TLM_COMPLETED;
+                });
+#endif
+        }
+
+        isock.bind(dut.socket);
+        SC_THREAD(run);
+    }
+
+    void write32(uint64_t addr, uint32_t val) {
+        tlm::tlm_generic_payload t;
+        t.set_command(tlm::TLM_WRITE_COMMAND);
+        t.set_address(addr);
+        t.set_data_ptr(reinterpret_cast<unsigned char*>(&val));
+        t.set_data_length(4);
+        t.set_streaming_width(4);
+        t.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
+        sc_core::sc_time d;
+        isock->b_transport(t, d);
+    }
+
+    uint32_t read32(uint64_t addr) {
+        uint32_t val{};
+        tlm::tlm_generic_payload t;
+        t.set_command(tlm::TLM_READ_COMMAND);
+        t.set_address(addr);
+        t.set_data_ptr(reinterpret_cast<unsigned char*>(&val));
+        t.set_data_length(4);
+        t.set_streaming_width(4);
+        t.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
+        sc_core::sc_time d;
+        isock->b_transport(t, d);
+        return val;
+    }
+
+    // Fire (or lower) an interrupt source and advance two delta cycles so
+    // the PLIC callback and its resulting output write both propagate.
+    void fire_irq(uint32_t src, bool val) {
+#ifdef SC_SIGNAL_IF
+        irq_src[src].write(val);
+        wait(sc_core::SC_ZERO_TIME);  // signal propagates to PLIC
+        wait(sc_core::SC_ZERO_TIME);  // PLIC output write propagates
+#else
+        tlm::scc::tlm_signal_gp<bool> gp;
+        gp.set_value(val);
+        sc_core::sc_time tt = sc_core::SC_ZERO_TIME;
+        tlm::tlm_phase  p  = tlm::BEGIN_REQ;
+        irq_src[src]->nb_transport_fw(gp, p, tt);
+        wait(sc_core::SC_ZERO_TIME);
+#endif
+    }
+
+    bool get_irq(uint32_t ctx) {
+#ifdef SC_SIGNAL_IF
+        return irq_out[ctx].read();
+#else
+        return ctx_irq[ctx];
+#endif
+    }
+
+    void do_reset() {
+        rst_sig.write(true);
+        wait(sc_core::SC_ZERO_TIME);
+        rst_sig.write(false);
+        wait(sc_core::SC_ZERO_TIME);
+    }
+
+#define CHECK(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            std::cerr << "FAIL [line " << __LINE__ << "]: " << (msg) << "\n"; \
+            ++failures; \
+        } else { \
+            std::cout << "PASS: " << (msg) << "\n"; \
+        } \
+    } while (0)
+
+    void run();
+};
+
+void TestBench::run() {
+    clk_sig.write(sc_core::sc_time(10, sc_core::SC_NS));
+    wait(sc_core::SC_ZERO_TIME);
+    do_reset();
+
+    // -----------------------------------------------------------------------
+    // T1: Basic interrupt delivery
+    //   source 1, priority 1, enabled for ctx0 only, threshold 0 → ctx0 fires
+    // -----------------------------------------------------------------------
+    write32(PRIO(1),   1);
+    write32(ENABLE(0), 0x2u);  // bit 1 → source 1
+    write32(THRESH(0), 0);
+    fire_irq(0, true);
+    CHECK( get_irq(0), "T1: ctx0 asserts when source 1 fires");
+    CHECK(!get_irq(1), "T1: ctx1 stays low (source 1 not enabled for ctx1)");
+
+    // -----------------------------------------------------------------------
+    // T2: Claim returns the source ID, clears its pending bit, and de-asserts
+    //     the IRQ output immediately when no further pending interrupts remain.
+    // -----------------------------------------------------------------------
+    const uint32_t claimed_t2 = read32(CLAIM(0));
+    CHECK(claimed_t2 == 1, "T2: claim register returns source 1");
+    CHECK((read32(PENDING(0)) & 0x2u) == 0, "T2: pending bit 1 cleared after claim");
+    // handle_pending_irq is called inside claim_complete_read_cb; with no remaining
+    // pending interrupts it de-asserts the output immediately.
+    CHECK(!get_irq(0), "T2: ctx0 de-asserts after claim (no further pending interrupts)");
+
+    // -----------------------------------------------------------------------
+    // T3: Complete marks the source cleared so it can re-fire; the IRQ output
+    //     was already de-asserted by the T2 claim.
+    // -----------------------------------------------------------------------
+    fire_irq(0, false);        // lower source line before completing
+    write32(CLAIM(0), 1);      // complete: sets src_irq_cleared[0]=true so source can re-fire
+    wait(sc_core::SC_ZERO_TIME);
+    CHECK(!get_irq(0), "T3: ctx0 stays de-asserted after complete (no new trigger)");
+
+    // Re-fire: source cleared by complete → rising edge delivers the interrupt
+    fire_irq(0, true);
+    CHECK(get_irq(0), "T3: ctx0 re-fires after complete + re-trigger");
+
+    // Clean up for the next test
+    fire_irq(0, false);
+    const uint32_t reclaim = read32(CLAIM(0));   // claim: clears pending bit, de-asserts output
+    write32(CLAIM(0), reclaim);                  // complete: marks source 1 cleared
+    wait(sc_core::SC_ZERO_TIME);
+    CHECK(!get_irq(0), "T3: ctx0 stays de-asserted after cleanup complete");
+
+    write32(ENABLE(0), 0);
+    write32(PRIO(1), 0);
+    do_reset();
+
+    // -----------------------------------------------------------------------
+    // T4: Threshold filtering — priority equal to threshold is blocked
+    //   The PLIC requires prio > threshold (strict), so prio=1, thresh=1 → blocked
+    // -----------------------------------------------------------------------
+    write32(PRIO(2),   1);
+    write32(ENABLE(0), 0x4u);  // bit 2 → source 2
+    write32(THRESH(0), 1);
+    fire_irq(1, true);
+    CHECK(!get_irq(0), "T4: prio==threshold blocks delivery (prio 1, thresh 1)");
+
+    // Raise priority above threshold → still no retroactive delivery (no re-trigger)
+    write32(PRIO(2), 2);
+    wait(sc_core::SC_ZERO_TIME);
+    CHECK(!get_irq(0), "T4: changing priority alone does not retrigger delivery");
+
+    fire_irq(1, false);
+    do_reset();  // flush the stuck pending bit
+
+    // -----------------------------------------------------------------------
+    // T5: Priority arbitration — claim returns highest-priority pending source
+    //   source 3 (prio 2) and source 4 (prio 3) both pending;
+    //   claim must return 4 first, then 3 after completing 4.
+    // -----------------------------------------------------------------------
+    write32(PRIO(3),   2);
+    write32(PRIO(4),   3);
+    write32(ENABLE(0), 0x18u);  // bits 3 and 4
+    write32(THRESH(0), 0);
+
+    fire_irq(2, true);   // ctx0 asserts (first pending interrupt)
+    fire_irq(3, true);   // ctx0 already pending; no second pulse
+
+    CHECK(get_irq(0), "T5: ctx0 asserts with sources 3 and 4 both pending");
+
+    const uint32_t c5a = read32(CLAIM(0));
+    CHECK(c5a == 4, "T5: claim returns source 4 (highest priority)");
+
+    fire_irq(2, false);
+    fire_irq(3, false);
+    write32(CLAIM(0), 4);       // complete source 4
+    wait(sc_core::SC_ZERO_TIME);
+    // output stays asserted: handle_pending_irq found source 3 still pending during the claim of source 4
+    CHECK(get_irq(0), "T5: ctx0 remains asserted for source 3 after completing source 4");
+
+    const uint32_t c5b = read32(CLAIM(0));
+    CHECK(c5b == 3, "T5: claim returns source 3 after source 4 completed");
+
+    write32(CLAIM(0), 3);       // complete source 3
+    wait(sc_core::SC_ZERO_TIME);
+    CHECK(!get_irq(0), "T5: ctx0 de-asserts after both sources completed");
+
+    write32(ENABLE(0), 0);
+    write32(PRIO(3), 0);
+    write32(PRIO(4), 0);
+
+    // -----------------------------------------------------------------------
+    // T6: Context isolation — source enabled for ctx0 only, ctx1 unaffected
+    // -----------------------------------------------------------------------
+    write32(PRIO(5),   1);
+    write32(ENABLE(0), 0x20u);  // bit 5 → source 5 for ctx0
+    write32(ENABLE(1), 0);      // nothing for ctx1
+    write32(THRESH(0), 0);
+    write32(THRESH(1), 0);
+
+    fire_irq(4, true);
+    CHECK( get_irq(0), "T6: ctx0 asserts for source 5");
+    CHECK(!get_irq(1), "T6: ctx1 stays low (source 5 not enabled for ctx1)");
+
+    fire_irq(4, false);
+    write32(CLAIM(0), read32(CLAIM(0)));  // claim then complete source 5
+    wait(sc_core::SC_ZERO_TIME);
+    write32(CLAIM(0), 5);
+    wait(sc_core::SC_ZERO_TIME);
+    CHECK(!get_irq(0), "T6: ctx0 de-asserts after complete");
+
+    write32(ENABLE(0), 0);
+    write32(PRIO(5), 0);
+
+    // -----------------------------------------------------------------------
+    // T7: Multiple pending — second interrupt does not re-pulse ctx;
+    //     interrupts are delivered sequentially via claim/complete.
+    //   source 6 (prio 1), source 7 (prio 2)
+    // -----------------------------------------------------------------------
+    write32(PRIO(6),   1);
+    write32(PRIO(7),   2);
+    write32(ENABLE(0), 0xC0u);  // bits 6 and 7
+    write32(THRESH(0), 0);
+
+    fire_irq(5, true);
+    CHECK(get_irq(0), "T7: ctx0 asserts on source 6");
+
+    fire_irq(6, true);   // ctx0 already asserted; handle_pending_irq re-evaluates but output stays high
+    CHECK(get_irq(0), "T7: ctx0 still asserted with source 7 also pending");
+
+    fire_irq(5, false);
+    fire_irq(6, false);
+
+    const uint32_t c7a = read32(CLAIM(0));
+    CHECK(c7a == 7, "T7: claim returns source 7 (higher priority)");
+
+    write32(CLAIM(0), 7);       // complete source 7
+    wait(sc_core::SC_ZERO_TIME);
+    // output stays asserted: handle_pending_irq found source 6 still pending during the claim of source 7
+    CHECK(get_irq(0), "T7: ctx0 remains asserted for source 6 after completing source 7");
+
+    const uint32_t c7b = read32(CLAIM(0));
+    CHECK(c7b == 6, "T7: claim returns source 6 next");
+
+    write32(CLAIM(0), 6);       // complete source 6
+    wait(sc_core::SC_ZERO_TIME);
+    CHECK(!get_irq(0), "T7: ctx0 fully de-asserts after both sources completed");
+
+    write32(ENABLE(0), 0);
+    write32(PRIO(6), 0);
+    write32(PRIO(7), 0);
+
+    // -----------------------------------------------------------------------
+    // T8: Reset clears all register state
+    // -----------------------------------------------------------------------
+    write32(PRIO(1),   7);
+    write32(ENABLE(0), 0xFFu);
+    write32(THRESH(0), 3);
+    do_reset();
+    CHECK(read32(PRIO(1))   == 0, "T8: priority[1] zeroed after reset");
+    CHECK(read32(ENABLE(0)) == 0, "T8: enable[ctx0] zeroed after reset");
+    CHECK(read32(THRESH(0)) == 0, "T8: threshold[ctx0] zeroed after reset");
+
+    // -----------------------------------------------------------------------
+    // T9: interrupts_i[0] maps to PLIC source ID 1; source ID 0 is reserved
+    //     and unreachable via any interrupt input. Verify the index offset is
+    //     correct by firing index 0 and confirming source 1 is claimed.
+    // -----------------------------------------------------------------------
+    write32(PRIO(1),   1);
+    write32(ENABLE(0), 0x2u);   // bit 1 → source 1
+    write32(THRESH(0), 0);
+    fire_irq(0, true);           // index 0 → source ID 1
+    CHECK(get_irq(0), "T9: interrupts_i[0] triggers ctx0 (maps to source ID 1)");
+    const uint32_t c9 = read32(CLAIM(0));
+    CHECK(c9 == 1, "T9: claim returns source ID 1, confirming index-to-ID offset");
+    fire_irq(0, false);
+    write32(CLAIM(0), 1);
+    wait(sc_core::SC_ZERO_TIME);
+    CHECK(!get_irq(0), "T9: ctx0 de-asserts after completing source 1");
+
+    sc_core::sc_stop();
+}
+
+int sc_main(int /*argc*/, char* /*argv*/[]) {
+    scc::init_logging(scc::log::WARNING);
+    TestBench tb{"tb"};
+    sc_core::sc_start();
+
+    if (tb.failures > 0) {
+        std::cerr << tb.failures << " PLIC test(s) FAILED\n";
+        return 1;
+    }
+    std::cout << "All PLIC tests PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
Adding a new RISC-V compliant PLIC model (`vpvper::rvi::plic`) along with some optional functional tests. This PLIC model supports multiple targets/contexts, so it can be used with multi-core/hart models.